### PR TITLE
Fix typo in Todoist migration doc

### DIFF
--- a/src/content/docs/setup/todoist.mdoc
+++ b/src/content/docs/setup/todoist.mdoc
@@ -104,7 +104,7 @@ If the Todoist icon doesn't appear in the import section:
 After the migration is complete, you can:
 
 1. Remove the Todoist integration from your Todoist account if no longer needed
-2. Remove the configration for the Todoist migration from your Vikunja configuration file or environment variables
+2. Remove the configuration for the Todoist migration from your Vikunja configuration file or environment variables
 3. Restart your Vikunja container to apply the cleanup
 
 The migration is now complete, and all your Todoist tasks and projects should be available in Vikunja.


### PR DESCRIPTION
## Summary
- fix a typo in the Todoist migration cleanup list