### PR TITLE
Fix frontend README link

### DIFF
--- a/src/content/docs/development/development.mdoc
+++ b/src/content/docs/development/development.mdoc
@@ -42,7 +42,7 @@ Make sure to check the other doc articles for specific development tasks like [t
 ## Frontend requirements
 
 The code for the frontend is located in the `frontend` sub folder of the main repo.
-More instructions can be found in the repo's README.
+More instructions can be found in [the repo's README](https://github.com/go-vikunja/vikunja/blob/main/frontend/README.md).
 
 You need to have [pnpm](https://pnpm.io/) and Node.JS in version 20 or higher installed.
 


### PR DESCRIPTION
## Summary
- link to the frontend README from the development docs

## Testing
- `pnpm run lint` *(fails: Parameter implicitly has an `any` type)*
- `pnpm run build`

------
https://chatgpt.com/codex/tasks/task_e_68457b26d21c8320bb49115109639065