### PR TITLE
Disable Astro telemetry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:22-bookworm AS build
 WORKDIR /app
+ENV ASTRO_TELEMETRY_DISABLED=1
 COPY . .
 RUN corepack enable && \
     pnpm install --frozen-lockfile && \
@@ -7,6 +8,7 @@ RUN corepack enable && \
 
 FROM node:22-bookworm AS runtime
 WORKDIR /app
+ENV ASTRO_TELEMETRY_DISABLED=1
 
 ENV NGINX_VERSION   1.27.0
 ENV NJS_VERSION     0.8.4


### PR DESCRIPTION
## Summary
- disable Astro telemetry during Docker build and runtime

## Testing
- `pnpm run lint` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863bb0de7f083209c215bbb023b4803